### PR TITLE
ci: added action for collecting repo stats

### DIFF
--- a/.github/workflows/repo-stats-collector.yml
+++ b/.github/workflows/repo-stats-collector.yml
@@ -1,0 +1,17 @@
+name: Collect Repository Stats
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  j1:
+    if: github.repository == 'sarvsav/go-starter-template'
+    name: repostats-for-project
+    runs-on: ubuntu-latest
+    steps:
+      - name: run-ghrs
+        uses: jgehrcke/github-repo-stats@RELEASE
+        with:
+          repository: sarvsav/go-starter-template
+          ghtoken: ${{ secrets.PERSONAL_GITHUB_TOKEN }}

--- a/.github/workflows/test-docusaurus.yml
+++ b/.github/workflows/test-docusaurus.yml
@@ -11,6 +11,9 @@ jobs:
   test-deploy:
     name: Test deployment
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,6 +22,7 @@ jobs:
         with:
           node-version: 18
           cache: npm
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Change to docs directory
         run: cd docs


### PR DESCRIPTION
Why: To get stats more than 14 days to handle github limitation

How: By using github action from jgehrcke

Tags: [actions]

# Pull Request 🚀

## Description 📝

[Describe what this PR accomplishes]

## Related Issue (Bug 🐛, Feature 💡, Documentation 📄)

[Closes #(issue number)]

## Checklist ✅

- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have tested this code locally.
- [ ] I have added appropriate comments to my code.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the coding style guidelines.

## Screenshots (if applicable) 🖼️

[Attach any relevant screenshots or GIFs]

## Additional Notes ℹ️

[Add any additional notes or context for reviewers]

## Links to resources 🔗

[Provides the link that has been used to solve this issue]
